### PR TITLE
fix: explicit type exports

### DIFF
--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -222,8 +222,8 @@ class GenerateCommand extends Command
                 ->replace('\\', '/');
                 
             $enumName = Str::of($relativePath)->afterLast('/')->studly();
-            
-            $indexContent .= "export { default as {$enumName}, {$enumName}Type, {$enumName}Utils } from './{$relativePath}';\n";
+
+            $indexContent .= "export { default as {$enumName}, type {$enumName}Type, {$enumName}Utils } from './{$relativePath}';\n";
         }
         
         File::ensureDirectoryExists(dirname($indexPath));

--- a/tests/Feature/GenerateCommandTest.php
+++ b/tests/Feature/GenerateCommandTest.php
@@ -94,8 +94,8 @@ class GenerateCommandTest extends TestCase
         ]);
 
         $indexContent = File::get('tests/output/index.ts');
-        
-        $this->assertStringContainsString('export { default as UserRole, UserRoleType, UserRoleUtils }', $indexContent);
-        $this->assertStringContainsString('export { default as Status, StatusType, StatusUtils }', $indexContent);
+
+        $this->assertStringContainsString('export { default as UserRole, type UserRoleType, UserRoleUtils }', $indexContent);
+        $this->assertStringContainsString('export { default as Status, type StatusType, StatusUtils }', $indexContent);
     }
 } 


### PR DESCRIPTION
Hey @bdweix - this package is great! 👍

When `isolatedModules` is set to true in `tsconfig`, ts will error on the exports generated in `index.ts`:

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/b2c8965c-f7f1-45e0-bf81-4dbeb929bcef" />

Simple fix to add explicit `type` prefix to type exports:

```ts
// before 
export { default as UbuntuVersion, UbuntuVersionType, UbuntuVersionUtils } from './ubuntu-version';

// after
export { default as UbuntuVersion, type UbuntuVersionType, UbuntuVersionUtils } from './ubuntu-version';
```

Works with or without `isolatedModules` set to true.

