### PR TITLE
fix: update signature, use config values

### DIFF
--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class GenerateCommand extends Command
 {
-    protected $signature = 'ts-enum:generate
+    protected $signature = 'ts-enums:generate
                            {--source= : Source directory for PHP enums}
                            {--destination= : Destination directory for TypeScript files}
                            {--watch : Watch for changes and regenerate automatically}';

--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -12,9 +12,9 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class GenerateCommand extends Command
 {
-    protected $signature = 'ts-enums:generate 
-                           {--source=app/Enums : Source directory containing PHP enums}
-                           {--destination=resources/ts/enums : Destination directory for TypeScript files}
+    protected $signature = 'ts-enum:generate
+                           {--source= : Source directory for PHP enums}
+                           {--destination= : Destination directory for TypeScript files}
                            {--watch : Watch for changes and regenerate automatically}';
     
     protected $description = 'Generate runtime-usable TypeScript enums from PHP enums';
@@ -37,9 +37,9 @@ class GenerateCommand extends Command
 
     private function setOptions(): void
     {
-        $this->sourceDir = $this->option('source');
-        $this->destinationDir = $this->option('destination');
-        
+        $this->sourceDir = $this->option('source') ?: config('ts-enum-generator.default_source_dir');
+        $this->destinationDir = $this->option('destination') ?: config('ts-enum-generator.default_destination_dir');
+
         // Convert relative paths to absolute for proper resolution
         if (!str_starts_with($this->sourceDir, '/')) {
             $this->sourceDir = getcwd() . '/' . $this->sourceDir;

--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Finder\SplFileInfo;
 class GenerateCommand extends Command
 {
     protected $signature = 'ts-enums:generate
-                           {--source= : Source directory for PHP enums}
+                           {--source= : Source directory containing PHP enums}
                            {--destination= : Destination directory for TypeScript files}
                            {--watch : Watch for changes and regenerate automatically}';
     

--- a/tests/Feature/GenerateCommandTest.php
+++ b/tests/Feature/GenerateCommandTest.php
@@ -105,8 +105,8 @@ class GenerateCommandTest extends TestCase
     public function itUsesTheConfiguredSourceAndDestinationIfNoneAreProvided()
     {
         // Given
-        Config::set('ts-enums.source', 'tests/fixtures/enums');
-        Config::set('ts-enums.destination', 'tests/output');
+        Config::set('ts-enum-generator.default_source_dir', 'tests/fixtures/enums');
+        Config::set('ts-enum-generator.default_destination_dir', 'tests/output/somewhere');
 
         // When
         $this->artisan('ts-enums:generate')
@@ -115,8 +115,8 @@ class GenerateCommandTest extends TestCase
              ->assertExitCode(0);
 
         // Then
-        $this->assertTrue(File::exists('tests/output/user-role.ts'));
-        $this->assertTrue(File::exists('tests/output/status.ts'));
-        $this->assertTrue(File::exists('tests/output/index.ts'));
+        $this->assertTrue(File::exists('tests/output/somewhere/user-role.ts'));
+        $this->assertTrue(File::exists('tests/output/somewhere/status.ts'));
+        $this->assertTrue(File::exists('tests/output/somewhere/index.ts'));
     }
 }

--- a/tests/Feature/GenerateCommandTest.php
+++ b/tests/Feature/GenerateCommandTest.php
@@ -3,7 +3,9 @@
 namespace Diagonal\TsEnumGenerator\Tests\Feature;
 
 use Diagonal\TsEnumGenerator\Tests\TestCase;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 
 class GenerateCommandTest extends TestCase
 {
@@ -27,7 +29,7 @@ class GenerateCommandTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_generate_typescript_enums_from_php_enums()
     {
         $this->artisan('ts-enums:generate', [
@@ -44,7 +46,7 @@ class GenerateCommandTest extends TestCase
         $this->assertTrue(File::exists('tests/output/index.ts'));
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_correct_typescript_for_backed_enum()
     {
         $this->artisan('ts-enums:generate', [
@@ -67,7 +69,7 @@ class GenerateCommandTest extends TestCase
         $this->assertStringContainsString('isValid: (value: any): value is UserRoleType', $userRoleContent);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_correct_typescript_for_pure_enum()
     {
         $this->artisan('ts-enums:generate', [
@@ -85,7 +87,7 @@ class GenerateCommandTest extends TestCase
         $this->assertStringContainsString('APPROVED: \'APPROVED\' as const,', $statusContent);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_index_file_with_all_exports()
     {
         $this->artisan('ts-enums:generate', [
@@ -98,4 +100,23 @@ class GenerateCommandTest extends TestCase
         $this->assertStringContainsString('export { default as UserRole, type UserRoleType, UserRoleUtils }', $indexContent);
         $this->assertStringContainsString('export { default as Status, type StatusType, StatusUtils }', $indexContent);
     }
-} 
+
+    #[Test]
+    public function itUsesTheConfiguredSourceAndDestinationIfNoneAreProvided()
+    {
+        // Given
+        Config::set('ts-enums.source', 'tests/fixtures/enums');
+        Config::set('ts-enums.destination', 'tests/output');
+
+        // When
+        $this->artisan('ts-enums:generate')
+             ->expectsOutput('Generating runtime-usable TypeScript enums...')
+             ->expectsOutput('TypeScript enums generated successfully.')
+             ->assertExitCode(0);
+
+        // Then
+        $this->assertTrue(File::exists('tests/output/user-role.ts'));
+        $this->assertTrue(File::exists('tests/output/status.ts'));
+        $this->assertTrue(File::exists('tests/output/index.ts'));
+    }
+}


### PR DESCRIPTION
One more little fix

- fix: replaces deprecated `@test` comment with `#[Test]` attribute
- fix: ensures command parameters use config values if no parameters present
	- adds test	 

@bdweix already using this @springloadedco, loving it